### PR TITLE
create subdirectories for domain paths

### DIFF
--- a/cmd/irestore/irestore.go
+++ b/cmd/irestore/irestore.go
@@ -203,7 +203,8 @@ func restore(db *backup.MobileBackup, domain string, dest string) {
 		if rec.Length > 0 {
 			var outPath string
 			if domain == "*" {
-				outPath = path.Join(dest, rec.Domain, rec.Path)
+        domainPath := strings.Replace(rec.Domain, "-", "/", -1)
+				outPath = path.Join(dest, domainPath, rec.Path)
 			} else if rec.Domain == domain {
 				outPath = path.Join(dest, rec.Path)
 			}


### PR DESCRIPTION
In the domain column of the Manifest.db Files table, logical subdirectories are delineated with a `-`. By replacing the `-` with a `/`, the directory structure on a full restore (e.g. with `*` as the domain) is created with a more logical structure. For example, instead of a directory in the top level restore directory _for each app_, e.g.:
```
AppDomain-com.apple.mobilesafari
AppDomain-com.yelp.yelpiphone
<snip>
```

each app would have a directory under AppDomain which changes for a bunch of directories like:

```
AppDomain
  |--- com.apple.mobilesafari
  |--- com.yelp.yelpiphone
<snip>
```
This makes exploring the various domains easier as the structure of how data is stored is more accurately represented in the restore directory.