### PR TITLE
feat: add `restore-all` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Selected MyPad 43686f636f6c61746552616d656b696e73546f6f
 Usage:
     ls [domain]
     restore domain dest
+    restore-all dest
     dumpkeys [outputfile]
     apps
 ```
@@ -27,6 +28,8 @@ Usage:
 The `ls` command will list domains or files in a domain.
 
 The `restore` command will restore the files in a domain into a directory tree.
+
+The `restore-all` command will restore the all files into a directory tree.
 
 The `dumpkeys` command will dump the readable portions of the keychain to json.
 

--- a/cmd/irestore/irestore.go
+++ b/cmd/irestore/irestore.go
@@ -289,6 +289,7 @@ func main() {
 		fmt.Println(`Usage:
     ls [domain]
     restore domain dest
+    restore-all dest
     dumpkeys [outputfile]
     apps
 `)
@@ -308,6 +309,15 @@ func main() {
 	case "restore":
 		if len(os.Args) > 4 {
 			restore(db, os.Args[3], os.Args[4])
+		} else {
+			help()
+		}
+	case "restore-all":
+		if len(os.Args) > 3 {
+			for _, domain := range db.Domains() {
+				outPath := path.Join(os.Args[3] + domain)
+				restore(db, domain, outPath)
+			}
 		} else {
 			help()
 		}


### PR DESCRIPTION
Thanks to @dunhamsteve for this tool, it helped me solve my problem today. But when I had a little trouble using it I got this PR after trying to solve it.

Since I don't understand the iOS backup mechanism, when I need to `irestore restore xxx out`, I don't really know what domain name I want to work with. For that reason, when I try to use `irestore list` to find my target, I unfortunately get a long list, which makes it difficult for me.

So I'm going to restore all the domains and identify my target by their contents. So I tried the `xargs` command, however, my backup was an encrypted backup so I had to repeatedly enter the password many times, and `irestore` consumed so much time in the frequent decryption process that I finally gave up and tried to fix its source code.

Fortunately, irestore's source code is very clear and easy to read, and I quickly implemented a `restore-all` command, which successfully freed all the backup files. I thought someone else might have a similar problem, so I thought I'd submit this PR to help others.