### PR TITLE
Add support for Windows

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path"
 	"sort"
+	"runtime"
 
 	"github.com/dunhamsteve/ios/crypto/aeswrap"
 	"github.com/dunhamsteve/ios/keybag"
@@ -355,8 +356,15 @@ type Backup struct {
 // Enumerate lists the available backups
 func Enumerate() ([]Backup, error) {
 	var all []Backup
-	home := os.Getenv("HOME")
-	dir := path.Join(home, "Library/Application Support/MobileSync/Backup")
+	var home string
+	var dir string
+	if runtime.GOOS == "windows" {
+		home = os.Getenv("APPDATA")
+		dir = path.Join(home, "Apple/MobileSync/Backup")
+	} else {
+		home = os.Getenv("HOME")
+		dir = path.Join(home, "Library/Application Support/MobileSync/Backup")
+	}
 	r, err := os.Open(dir)
 	if err != nil {
 		return nil, err
@@ -385,9 +393,15 @@ func Enumerate() ([]Backup, error) {
 // Open opens a MobileBackup directory corresponding to a given guid.
 func Open(guid string) (*MobileBackup, error) {
 	var backup MobileBackup
+	var home string
+	if runtime.GOOS == "windows" {
+		home = os.Getenv("APPDATA")
+		backup.Dir = path.Join(home, "Apple/MobileSync/Backup", guid)
+	} else {
+		home = os.Getenv("HOME")
+		backup.Dir = path.Join(home, "Library/Application Support/MobileSync/Backup", guid)
+	}
 
-	home := os.Getenv("HOME")
-	backup.Dir = path.Join(home, "Library/Application Support/MobileSync/Backup", guid)
 	tmp := path.Join(backup.Dir, "Manifest.plist")
 	r, err := os.Open(tmp)
 	if err != nil {

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -435,7 +435,7 @@ func (mb *MobileBackup) decryptDatabase(fn string, mk []byte) (string, error) {
 	}
 	bm := cipher.NewCBCDecrypter(b, zeroiv)
 	bm.CryptBlocks(data, data)
-	out, err := ioutil.TempFile("/tmp", "db")
+	out, err := ioutil.TempFile("", "db")
 	if err != nil {
 		return "", err
 	}

--- a/cmd/irestore/irestore.go
+++ b/cmd/irestore/irestore.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"syscall"
 
 	"crypto/aes"
 
@@ -39,7 +40,7 @@ func dumpJSON(x interface{}) {
 
 func getpass() string {
 	fmt.Fprint(os.Stderr, "Backup Password: ")
-	pw, err := terminal.ReadPassword(0)
+	pw, err := terminal.ReadPassword(int(syscall.Stdin))
 	must(err)
 	fmt.Println()
 	return string(pw)


### PR DESCRIPTION
This pull request adds support for Windows by fixing a couple of minor issues. Apparently, the Microsoft Store version of iTunes writes backups to the `Apple/MobileSync/Backup` directory. The `Apple Computer/MobileSync/Backup` is used otherwise, this is not supported.