### PR TITLE
Fix backup path for Windows

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -360,7 +360,7 @@ func Enumerate() ([]Backup, error) {
 	var dir string
 	if runtime.GOOS == "windows" {
 		home = os.Getenv("APPDATA")
-		dir = path.Join(home, "Apple/MobileSync/Backup")
+		dir = path.Join(home, "Apple Computer\\MobileSync\\Backup")
 	} else {
 		home = os.Getenv("HOME")
 		dir = path.Join(home, "Library/Application Support/MobileSync/Backup")

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -396,7 +396,7 @@ func Open(guid string) (*MobileBackup, error) {
 	var home string
 	if runtime.GOOS == "windows" {
 		home = os.Getenv("APPDATA")
-		backup.Dir = path.Join(home, "Apple/MobileSync/Backup", guid)
+		backup.Dir = path.Join(home, "Apple Computer\\MobileSync\\Backup", guid)
 	} else {
 		home = os.Getenv("HOME")
 		backup.Dir = path.Join(home, "Library/Application Support/MobileSync/Backup", guid)


### PR DESCRIPTION
It originally tried looking in the "Apple" folder in AppData, but it fails because the folder is actually called "Apple Computer"