### PR TITLE
Add support for alternate Windows backup location

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -361,6 +361,9 @@ func Enumerate() ([]Backup, error) {
 	if runtime.GOOS == "windows" {
 		home = os.Getenv("APPDATA")
 		dir = path.Join(home, "Apple Computer\\MobileSync\\Backup")
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			dir = path.Join(home, "Apple\\MobileSync\\Backup")
+		}
 	} else {
 		home = os.Getenv("HOME")
 		dir = path.Join(home, "Library/Application Support/MobileSync/Backup")
@@ -397,6 +400,9 @@ func Open(guid string) (*MobileBackup, error) {
 	if runtime.GOOS == "windows" {
 		home = os.Getenv("APPDATA")
 		backup.Dir = path.Join(home, "Apple Computer\\MobileSync\\Backup", guid)
+		if _, err := os.Stat(backup.Dir); os.IsNotExist(err) {
+			backup.Dir = path.Join(home, "Apple\\MobileSync\\Backup", guid)
+		}
 	} else {
 		home = os.Getenv("HOME")
 		backup.Dir = path.Join(home, "Library/Application Support/MobileSync/Backup", guid)


### PR DESCRIPTION
This pull request checks for both the "Apple" and "Apple Computer" directories as "Apple" is used when iTunes is downloaded from the Microsoft Store.